### PR TITLE
Allow resolve_type to return a string

### DIFF
--- a/graphene/types/schema.py
+++ b/graphene/types/schema.py
@@ -396,6 +396,8 @@ class TypeMap(dict):
 
         if inspect.isclass(type_) and issubclass(type_, ObjectType):
             return type_._meta.name
+        elif isinstance(type_, str):
+            return type_
 
         return_type = self[type_name]
         return default_type_resolver(root, info, return_type)


### PR DESCRIPTION
A change in https://github.com/graphql-python/graphene/pull/1421 broke a use case where the an interface's resolve_type method could return the name of the type (as opposed to the Type itself). This restores the behavior by allowing implementations to return the name of the GraphQL type directly.